### PR TITLE
Refactored and updated doclet, included documentation and sample project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 /.classpath
 /.project
 /.settings/
-.idea/*
-sample/.idea/*
+**/.idea/*
 *~
 *.iml
 target

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.project
 /.settings/
 .idea/*
+sample/.idea/*
 *~
 *.iml
 target

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,10 @@
 = ExportDoclet
 
 image:https://travis-ci.org/johncarl81/exportdoclet.svg?branch=master["Build Status", link="https://travis-ci.org/johncarl81/exportdoclet"] 
+image:https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/exportdoclet/badge.svg["Maven Central", link="https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/exportdoclet"]
+image:https://img.shields.io/bintray/v/asciidoctor/maven/asciidoclet.svg["Download", link="https://bintray.com/asciidoctor/maven/asciidoclet"]
+
+
 
 A link:http://docs.oracle.com/javase/1.5.0/docs/guide/javadoc/doclet/overview.html[Doclet] that allows exporting javadoc
 comments containing link:http://asciidoctor.org[AsciiDoc] text to AsciiDoc files, enabling combining the javadocs into a broader AsciiDoc documentation for your Java project.
@@ -33,7 +37,7 @@ the next steps in a terminal:
 
 - Enter into the folder that contains the java files with javadoc comments you want to export
 - Execute `javadoc -docletpath $DOCLETJAR -doclet org.asciidoctor.ExportDoclet -d $OUTPUTDIR *.java`, where: 
-    ** `$DOCLETJAR` is the path for the ExportDoclet jar file (that you built using the instructions in the previous section, or downloaded from maven central) 
+    ** `$DOCLETJAR` is the path for the ExportDoclet jar file (that you built using the instructions in the previous section, downloaded from link:https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/exportdoclet[maven central] or link:https://bintray.com/asciidoctor/maven/asciidoclet[bintray]) 
     ** `$OUTPUTDIR` is where you want to save the exported asciidoc files.
 
 === Using ExportDoclet with Maven javadoc plugin

--- a/README.adoc
+++ b/README.adoc
@@ -135,6 +135,7 @@ mvn package
 You can see a link:sample[sample project] that has some java files with javadocs containing AsciiDoc, and that has everything configured in the pom.xml.
 
 == How to use the generated AsciiDoc Files
+
 After using the ExportDoclet to export the javadoc comments written in AsciiDoc, you can put together your entire project documentation (javadocs, quick start guides, user guides, FAQs, etc) and exporting them to several different formats such as beautiful HTMLs, PDF, epub or any other format supported by  link:http://asciidoctor.org[AsciiDoctor].
 
 In order to accomplish that, you can use the link:https://github.com/asciidoctor/asciidoctor-maven-plugin[Maven AsciiDoctor Plugin] to automate the process of collecting all AsciiDoc files, that compound the entire project documentation, and export them to any deployment format such as HTML or PDF.

--- a/README.adoc
+++ b/README.adoc
@@ -1,41 +1,48 @@
 = ExportDoclet
 
-image:https://travis-ci.org/johncarl81/exportdoclet.svg?branch=master["Build Status", link="https://travis-ci.org/johncarl81/exportdoclet"] image:http://img.shields.io/badge/license-ASF2-blue.svg["Apache License 2", link="http://www.apache.org/licenses/LICENSE-2.0.txt"]
+image:https://travis-ci.org/johncarl81/exportdoclet.svg?branch=master["Build Status", link="https://travis-ci.org/johncarl81/exportdoclet"] 
 
 A link:http://docs.oracle.com/javase/1.5.0/docs/guide/javadoc/doclet/overview.html[Doclet] that allows exporting javadoc
-comments containing link:http://asciidoctor.org[AsciiDoc] text to AsciiDoc files, enabling combining the javadoc
-documentation into the AsciiDoc documentation for your Java project.
+comments containing link:http://asciidoctor.org[AsciiDoc] text to AsciiDoc files, enabling combining the javadocs into a broader AsciiDoc documentation for your Java project.
 
-Instead of exporting the javadoc comments to standard HTML files, the ExportDoclet exports them to AsciiDoc files,
-that in turn can converted to any output format supported by the link:http://asciidoctor.org[AsciiDoctor toolchain].
+Instead of exporting the javadoc comments to standard HTML files, the ExportDoclet exports them to AsciiDoc files, that in turn can be converted to any output format supported by the link:http://asciidoctor.org[AsciiDoctor toolchain].
+
+Using the ExportDoctor, one can put together the source code documentation (javadocs written in AsciiDoc), quick start guides, user guides, FAQs and any other documentation for Java projects. 
+
+AsciiDoc is a non-disturbing and clean markup language that you can use to write your javadocs. It provides a fast, elegant and professional way to write your documentation, beyond allowing the use of several new resources such as automatic code highlight and inclusion of snippets of code from your source files, providing a powerful way to keep your documentation updated with your code. 
+
+ExportDoclet encourages developers to write meaninguful and expanded documentation that goes beyond the source code documentation, by enabling the integration with other plugins such as the link:https://github.com/asciidoctor/asciidoclet[AsciiDoclet] and link:https://github.com/asciidoctor/asciidoctor-maven-plugin[Maven AsciiDoctor Plugin].
 
 == Building the ExportDoclet
 
 ExportDoclet is a Java Maven project that can be built directly from any IDE or using the following maven command:
 
 [source,bash]
-mvn clean package install
+mvn clean install
 
 That will build the tool and install it at your local maven repository, usually at the .m2 directory
 inside your home directory.
 
-== Using the ExportDoclet with javadoc by command line
+== How to use ExportDoclet
+There are different ways to use the ExportDoclet together with the javadoc tool, depending on your goal and project type. The next sub-sections present some of these ways.
+
+=== Using the ExportDoclet with javadoc by command line
 
 To manually call the javadoc tool by command line using the ExportDoclet you have to follow
 the next steps in a terminal:
 
 - Enter into the folder that contains the java files with javadoc comments you want to export
-- Execute `javadoc -docletpath $DOCLETJAR -doclet org.asciidoctor.ExportDoclet -d $OUTPUTDIR *.java`,
-where `$DOCLETJAR` is the path for the ExportDoclet jar file and `$OUTPUTDIR` is where you want
-to save the exported javadocs.
+- Execute `javadoc -docletpath $DOCLETJAR -doclet org.asciidoctor.ExportDoclet -d $OUTPUTDIR *.java`, where: 
+    ** `$DOCLETJAR` is the path for the ExportDoclet jar file (that you built using the instructions in the previous section, or downloaded from maven central) 
+    ** `$OUTPUTDIR` is where you want to save the exported asciidoc files.
 
-== Using ExportDoclet with Maven javadoc plugin
+=== Using ExportDoclet with Maven javadoc plugin
 
 Using the ExportDoclet with Maven is pretty simple. You can include the maven-javadoc-plugin configuration inside the `<build>` section of project's pom.xml file, defining the required configuration for the javadoc command line tool that was used above. 
 
 The sub-sections below present some distinct configurations.
 
-=== Generating only the AsciiDoc files
+==== Generating only the AsciiDoc files
 
 To generate just the AsciiDoc files and ignore the genration of the default HTML files, you can include the following code to the `<build>` section of your project's pom.xml.
 
@@ -64,7 +71,7 @@ mvn javadoc:javadoc
 
 The exported javadocs to AsciiDoc files will be found at target/site/apidocs directory.
 
-=== Generating both the AsciiDoc and default HTML files
+==== Generating both the AsciiDoc and default HTML files
 
 If you want to generate both the AsciiDoc and HTML files, that requires two different configurations for the maven-javadoc-plugin, as exemplified below:
 
@@ -125,15 +132,20 @@ Now, to generate the javadocs both in AsciiDoc and HTML files, you can execute t
 [source,bash]
 mvn package
 
-
 You can see a link:sample[sample project] that has some java files with javadocs containing AsciiDoc, and that has everything configured in the pom.xml.
+
+== How to use the generated AsciiDoc Files
+After using the ExportDoclet to export the javadoc comments written in AsciiDoc, you can put together your entire project documentation (javadocs, quick start guides, user guides, FAQs, etc) and exporting them to several different formats such as beautiful HTMLs, PDF, epub or any other format supported by  link:http://asciidoctor.org[AsciiDoctor].
+
+In order to accomplish that, you can use the link:https://github.com/asciidoctor/asciidoctor-maven-plugin[Maven AsciiDoctor Plugin] to automate the process of collecting all AsciiDoc files, that compound the entire project documentation, and export them to any deployment format such as HTML or PDF.
 
 == Contributors
 
 - link:http://twitter.com/manoelcampos[Manoel Campos da Silva Filho]
 
 == Additional References
-- link:http://www.manpagez.com/man/1/javadoc/[The javadoc command line manual]
-- link:http://www.oracle.com/technetwork/articles/java/index-jsp-135444.html[Javadoc Tool Home Page]
-- link:https://maven.apache.org/plugins/maven-javadoc-plugin[Javadoc Maven Plugin]
+- link:http://www.manpagez.com/man/1/javadoc/[The javadoc Command Line Manual]
+- link:http://www.oracle.com/technetwork/articles/java/index-jsp-135444.html[The javadoc Tool Home Page]
+- link:https://maven.apache.org/plugins/maven-javadoc-plugin[Maven javadoc Plugin]
 - link:https://github.com/asciidoctor/asciidoclet[AsciiDoclet]
+- link:https://github.com/asciidoctor/asciidoctor-maven-plugin[Maven AsciiDoctor Plugin]

--- a/README.adoc
+++ b/README.adoc
@@ -135,3 +135,5 @@ You can see a link:sample[sample project] that has some java files with javadocs
 == Additional References
 - link:http://www.manpagez.com/man/1/javadoc/[The javadoc command line manual]
 - link:http://www.oracle.com/technetwork/articles/java/index-jsp-135444.html[Javadoc Tool Home Page]
+- link:https://maven.apache.org/plugins/maven-javadoc-plugin[Javadoc Maven Plugin]
+- link:https://github.com/asciidoctor/asciidoclet[AsciiDoclet]

--- a/README.adoc
+++ b/README.adoc
@@ -57,7 +57,7 @@ To generate just the AsciiDoc files and ignore the genration of the default HTML
 </plugin>
 --
 
-Now, to generate the javadocs in AsciiDoc files you can execute the javadoc:javadoc goal in Maven, using your IDE or the command line inside your project root directory:
+Now, to generate the javadocs in AsciiDoc files you can execute the `javadoc:javadoc` goal in Maven, using your IDE or the command line inside your project root directory:
 
 [source,bash]
 mvn javadoc:javadoc
@@ -119,6 +119,12 @@ If you want to generate both the AsciiDoc and HTML files, that requires two diff
     </executions>
 </plugin>
 --
+
+Now, to generate the javadocs both in AsciiDoc and HTML files, you can execute the `package` goal in Maven, using your IDE or the command line inside your project root directory:
+
+[source,bash]
+mvn package
+
 
 You can see a link:sample[sample project] that has some java files with javadocs containing AsciiDoc, and that has everything configured in the pom.xml.
 

--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ comments containing link:http://asciidoctor.org[AsciiDoc] text to AsciiDoc files
 
 Instead of exporting the javadoc comments to standard HTML files, the ExportDoclet exports them to AsciiDoc files, that in turn can be converted to any output format supported by the link:http://asciidoctor.org[AsciiDoctor toolchain].
 
-Using the ExportDoctor, one can put together the source code documentation (javadocs written in AsciiDoc), quick start guides, user guides, FAQs and any other documentation for Java projects. 
+Using the ExportDoclet, one can put together the source code documentation (javadocs written in AsciiDoc), quick start guides, user guides, FAQs and any other documentation for Java projects. 
 
 AsciiDoc is a non-disturbing and clean markup language that you can use to write your javadocs. It provides a fast, elegant and professional way to write your documentation, beyond allowing the use of several new resources such as automatic code highlight and inclusion of snippets of code from your source files, providing a powerful way to keep your documentation updated with your code. 
 
@@ -35,7 +35,7 @@ the next steps in a terminal:
 
 - Enter into the folder that contains the java files with javadoc comments you want to export
 - Execute `javadoc -docletpath $DOCLETJAR -doclet org.asciidoctor.ExportDoclet -d $OUTPUTDIR *.java`, where: 
-    ** `$DOCLETJAR` is the path for the ExportDoclet jar file (that you built using the instructions in the previous section, downloaded from link:https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/exportdoclet[maven central] or link:https://bintray.com/asciidoctor/maven/asciidoclet[bintray]) 
+    ** `$DOCLETJAR` is the path for the ExportDoclet jar file (that you built using the instructions in the previous section, or downloaded from link:https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/exportdoclet[maven central] or link:https://bintray.com/asciidoctor/maven/asciidoclet[bintray]) 
     ** `$OUTPUTDIR` is where you want to save the exported asciidoc files.
 
 === Using ExportDoclet with Maven javadoc plugin
@@ -134,7 +134,7 @@ the AsciiDoclet tags inside your javadoc comments to HTML tags.
 Now, to generate the javadocs both in AsciiDoc and HTML files, you can execute the `package` goal in Maven, using your IDE or the command line inside your project root directory:
 
 [source,bash]
-mvn package
+mvn clean package
 
 You can see a link:sample[sample project] that has some java files with javadocs containing AsciiDoc, and that has everything configured in the pom.xml.
 

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ mvn clean package install
 That will build the tool and install it at your local maven repository, usually at the .m2 directory
 inside your home directory.
 
-== Using the ExportDoclet with javadoc tool
+== Using the ExportDoclet with javadoc by command line
 
 To manually call the javadoc tool by command line using the ExportDoclet you have to follow
 the next steps in a terminal:
@@ -29,9 +29,42 @@ the next steps in a terminal:
 where `$DOCLETJAR` is the path for the ExportDoclet jar file and `$OUTPUTDIR` is where you want
 to save the exported javadocs.
 
-== Using ExportDoclet with Maven
+== Using ExportDoclet with Maven javadoc plugin
 
-- Information will be provided soon
+Using the ExportDoclet with Maven is pretty simple. You can include the maven-javadoc-plugin configuration inside the `<build>` section of project's pom.xml file, defining the required configuration for the javadoc command line tool that was used above. 
+
+The sub-sections below present some distinct configurations.
+
+=== Generating only the AsciiDoc files
+
+To generate just the AsciiDoc files and ignore the genration of the default HTML files, you can include the following code to the `<build>` section of your project's pom.xml.
+
+[source,xml]
+--
+include::sample/pom.xml[tags=exportdoclet-only,indent=0]
+--
+
+Now, to generate the javadocs in AsciiDoc files you can execute the javadoc:javadoc goal in Maven, using your IDE or the command line inside your project root directory:
+
+[source,bash]
+mvn javadoc:javadoc
+
+The exported javadocs to AsciiDoc files will be found at target/site/apidocs directory.
+
+=== Generating both the AsciiDoc and default HTML files
+
+If you want to generate both the AsciiDoc and HTML files, that requires two different configurations for the maven-javadoc-plugin, as exemplified below:
+
+[source,xml]
+--
+include::sample/pom.xml[tags=asciidoclets,indent=0]
+--
+
+You can see a link:sample[sample project] that has some java files with javadocs containing AsciiDoc, and that has everything configured in the pom.xml.
+
+== Contributors
+
+- link:http://twitter.com/manoelcampos[Manoel Campos da Silva Filho]
 
 == Additional References
 - link:http://www.manpagez.com/man/1/javadoc/[The javadoc command line manual]

--- a/README.adoc
+++ b/README.adoc
@@ -4,8 +4,6 @@ image:https://travis-ci.org/johncarl81/exportdoclet.svg?branch=master["Build Sta
 image:https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/exportdoclet/badge.svg["Maven Central", link="https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/exportdoclet"]
 image:https://img.shields.io/bintray/v/asciidoctor/maven/asciidoclet.svg["Download", link="https://bintray.com/asciidoctor/maven/asciidoclet"]
 
-
-
 A link:http://docs.oracle.com/javase/1.5.0/docs/guide/javadoc/doclet/overview.html[Doclet] that allows exporting javadoc
 comments containing link:http://asciidoctor.org[AsciiDoc] text to AsciiDoc files, enabling combining the javadocs into a broader AsciiDoc documentation for your Java project.
 
@@ -77,7 +75,9 @@ The exported javadocs to AsciiDoc files will be found at target/site/apidocs dir
 
 ==== Generating both the AsciiDoc and default HTML files
 
-If you want to generate both the AsciiDoc and HTML files, that requires two different configurations for the maven-javadoc-plugin, as exemplified below:
+If you want to generate both the AsciiDoc and HTML files, that requires two different configurations for the maven-javadoc-plugin, 
+as exemplified below. That includes the link:https://github.com/asciidoctor/asciidoclet[AsciiDoclet] to enable converting
+the AsciiDoclet tags inside your javadoc comments to HTML tags.
 
 [source,xml]
 --

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,38 @@
-= Exportdoclet
+= ExportDoclet
 
-image:https://travis-ci.org/johncarl81/exportdoclet.svg?branch=master["Build Status", link="https://travis-ci.org/johncarl81/exportdoclet"]
+image:https://travis-ci.org/johncarl81/exportdoclet.svg?branch=master["Build Status", link="https://travis-ci.org/johncarl81/exportdoclet"] image:http://img.shields.io/badge/license-ASF2-blue.svg["Apache License 2", link="http://www.apache.org/licenses/LICENSE-2.0.txt"]
+
+A link:http://docs.oracle.com/javase/1.5.0/docs/guide/javadoc/doclet/overview.html[Doclet] that allows exporting javadoc
+comments containing link:http://asciidoctor.org[AsciiDoc] text to AsciiDoc files, enabling combining the javadoc
+documentation into the AsciiDoc documentation for your Java project.
+
+Instead of exporting the javadoc comments to standard HTML files, the ExportDoclet exports them to AsciiDoc files,
+that in turn can converted to any output format supported by the link:http://asciidoctor.org[AsciiDoctor toolchain].
+
+== Building the ExportDoclet
+
+ExportDoclet is a Java Maven project that can be built directly from any IDE or using the following maven command:
+
+[source,bash]
+mvn clean package install
+
+That will build the tool and install it at your local maven repository, usually at the .m2 directory
+inside your home directory.
+
+== Using the ExportDoclet with javadoc tool
+
+To manually call the javadoc tool by command line using the ExportDoclet you have to follow
+the next steps in a terminal:
+
+- Enter into the folder that contains the java files with javadoc comments you want to export
+- Execute `javadoc -docletpath $DOCLETJAR -doclet org.asciidoctor.ExportDoclet -d $OUTPUTDIR *.java`,
+where `$DOCLETJAR` is the path for the ExportDoclet jar file and `$OUTPUTDIR` is where you want
+to save the exported javadocs.
+
+== Using ExportDoclet with Maven
+
+- Information will be provided soon
+
+== Additional References
+- link:http://www.manpagez.com/man/1/javadoc/[The javadoc command line manual]
+- link:http://www.oracle.com/technetwork/articles/java/index-jsp-135444.html[Javadoc Tool Home Page]

--- a/README.adoc
+++ b/README.adoc
@@ -41,7 +41,20 @@ To generate just the AsciiDoc files and ignore the genration of the default HTML
 
 [source,xml]
 --
-include::sample/pom.xml[tags=exportdoclet-only,indent=0]
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-javadoc-plugin</artifactId>
+    <version>2.10.4</version>
+    <configuration>
+        <doclet>org.asciidoctor.ExportDoclet</doclet>
+        <docletArtifact>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>exportdoclet</artifactId>
+            <version>1.5.4-SNAPSHOT</version>
+        </docletArtifact>
+        <useStandardDocletOptions>true</useStandardDocletOptions>
+    </configuration>
+</plugin>
 --
 
 Now, to generate the javadocs in AsciiDoc files you can execute the javadoc:javadoc goal in Maven, using your IDE or the command line inside your project root directory:
@@ -57,7 +70,54 @@ If you want to generate both the AsciiDoc and HTML files, that requires two diff
 
 [source,xml]
 --
-include::sample/pom.xml[tags=asciidoclets,indent=0]
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-javadoc-plugin</artifactId>
+    <version>2.10.4</version>
+    <executions>
+        <!-- Exports javadocs containing AsciiDoc to HTML -->
+        <execution>
+            <id>html</id>
+            <phase>package</phase>
+            <goals>
+                <goal>javadoc</goal>
+            </goals>
+            <configuration>
+                <doclet>org.asciidoctor.Asciidoclet</doclet>
+                <docletArtifact>
+                    <groupId>org.asciidoctor</groupId>
+                    <artifactId>asciidoclet</artifactId>
+                    <version>1.5.4</version>
+                </docletArtifact>
+                <additionalparam>
+                    --base-dir ${project.basedir}
+                    --attribute "name=${project.name}"
+                    --attribute "version=${project.version}"
+                </additionalparam>
+            </configuration>
+        </execution>
+        <!-- Exports javadocs containing AsciiDoc to AsciiDoc files -->
+        <execution>
+            <id>asciidoc</id>
+            <phase>package</phase>
+            <goals>
+                <goal>javadoc</goal>
+            </goals>
+            <configuration>
+                <doclet>org.asciidoctor.ExportDoclet</doclet>
+                <docletArtifact>
+                    <groupId>org.asciidoctor</groupId>
+                    <artifactId>exportdoclet</artifactId>
+                    <version>1.5.4-SNAPSHOT</version>
+                </docletArtifact>
+                <useStandardDocletOptions>true</useStandardDocletOptions>
+                <additionalparam>
+                    -d "${project.build.directory}/site/asciidocs"
+                </additionalparam>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
 --
 
 You can see a link:sample[sample project] that has some java files with javadocs containing AsciiDoc, and that has everything configured in the pom.xml.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>jar</packaging>
     <version>1.5.4-SNAPSHOT</version>
 
-    <name>Output Doclet</name>
+    <name>Export Doclet</name>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -17,7 +17,7 @@
     </parent>
 
     <url>http://asciidoctor.org</url>
-    <description>Exportdoclet is a Javadoc Doclet that exports javadocs to files.</description>
+    <description>Exportdoclet is a Javadoc Doclet that exports javadocs written in AsciiDoc to adoc files.</description>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.asciidoctor</groupId>
     <artifactId>exportdoclet</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.5.4-SNAPSHOT</version>
 
     <name>Output Doclet</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,9 @@
                 <version>1.9.0</version>
                 <configuration>
                     <header>NOTICE</header>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
                     <includes>
                         <include>**/*.java</include>
                         <include>**/*.xml</include>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
-                    <finalName>${build.finalName}-all</finalName>
+                    <finalName>${project.build.finalName}-all</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.asciidoctor</groupId>
+    <artifactId>exportdoclet-sample</artifactId>
+    <version>1.0</version>
+
+    <description>
+    A sample project with a set of classes used just
+    to demonstrate how the org.asciidoctor.exportdoclet plugin exports
+    the javadoc from the project java files as AsciiDoc files.
+    </description>
+
+    <developers>
+        <developer>
+            <name>Manoel Campos da Silva Filho</name>
+            <url>http://twitter.com/manoelcampos</url>
+        </developer>
+    </developers>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceFormat>1.8</project.build.sourceFormat>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
+                <configuration>
+                    <source>${project.build.sourceFormat}</source>
+                    <target>${project.build.sourceFormat}</target>
+                </configuration>
+            </plugin>
+
+            <!--
+            Exports javadocs comments containing AsciiDoc to AsciiDoc files.
+            This plugin configuration must be used just if you want to generate
+            only the AsciiDoc files and ignore the generation of default HTML files.
+            In that case, the following plugin can be removed.
+
+            To execute the goal: mvn javadoc:javadoc
+            -->
+            <!-- tag::exportdoclet-only[] -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <configuration>
+                    <doclet>org.asciidoctor.ExportDoclet</doclet>
+                    <docletArtifact>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>exportdoclet</artifactId>
+                        <version>1.5.4-SNAPSHOT</version>
+                    </docletArtifact>
+                    <useStandardDocletOptions>true</useStandardDocletOptions>
+                </configuration>
+            </plugin>
+            <!-- end::exportdoclet-only[] -->
+
+            <!--
+            Exports javadocs comments containing AsciiDoc to both AsciiDoc and default HTML files.
+            This plugin configuration must be used just if you want to generate file formats.
+            In that case, the previous plugin can be removed.
+
+            To execute the goal: mvn package
+            -->
+            <!-- tag::asciidoclets[] -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <executions>
+                    <!-- Exports javadocs containing AsciiDoc to HTML -->
+                    <execution>
+                        <id>html</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                        <configuration>
+                            <doclet>org.asciidoctor.Asciidoclet</doclet>
+                            <docletArtifact>
+                                <groupId>org.asciidoctor</groupId>
+                                <artifactId>asciidoclet</artifactId>
+                                <version>1.5.4</version>
+                            </docletArtifact>
+                            <additionalparam>
+                                --base-dir ${project.basedir}
+                                --attribute "name=${project.name}"
+                                --attribute "version=${project.version}"
+                            </additionalparam>
+                        </configuration>
+                    </execution>
+                    <!-- Exports javadocs containing AsciiDoc to AsciiDoc files -->
+                    <execution>
+                        <id>asciidoc</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                        <configuration>
+                            <doclet>org.asciidoctor.ExportDoclet</doclet>
+                            <docletArtifact>
+                                <groupId>org.asciidoctor</groupId>
+                                <artifactId>exportdoclet</artifactId>
+                                <version>1.5.4-SNAPSHOT</version>
+                            </docletArtifact>
+                            <useStandardDocletOptions>true</useStandardDocletOptions>
+                            <additionalparam>
+                                -d "${project.build.directory}/site/asciidocs"
+                            </additionalparam>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- end::asciidoclets[] -->
+        </plugins>
+    </build>
+</project>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.asciidoctor</groupId>
     <artifactId>exportdoclet-sample</artifactId>
-    <version>1.0</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <description>
     A sample project with a set of classes used just

--- a/sample/src/main/java/people/Person.java
+++ b/sample/src/main/java/people/Person.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2016 John Ericksen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package people;
 
 /**

--- a/sample/src/main/java/people/Person.java
+++ b/sample/src/main/java/people/Person.java
@@ -1,0 +1,15 @@
+package people;
+
+/**
+ * An interface to represent different kinds of People.
+ *
+ * @author http://twitter.com/manoelcampos[Manoel Campos da Silva Filho]
+ * @see https://en.wikipedia.org/wiki/People[People at Wikipedia]
+ */
+public interface Person {
+    /**
+     * Gets the person's name.
+     * @return the name of the person
+     */
+    String getName();
+}

--- a/sample/src/main/java/vehicles/AbstractVehicle.java
+++ b/sample/src/main/java/vehicles/AbstractVehicle.java
@@ -1,0 +1,40 @@
+package vehicles;
+
+import people.Person;
+
+import java.time.LocalDate;
+
+/**
+ * An abstract class for implementing different kinds of {@link Vehicle}.
+ *
+ * @author http://twitter.com/manoelcampos[Manoel Campos da Silva Filho]
+ */
+public class AbstractVehicle implements Vehicle {
+    private int manufacturingYear;
+    private Person owner;
+
+    @Override
+    public int getManufacturingYear() {
+        return manufacturingYear;
+    }
+
+    @Override
+    public void setManufacturingYear(int year) {
+        this.manufacturingYear = year;
+    }
+
+    @Override
+    public Person getOwner() {
+        return owner;
+    }
+
+    @Override
+    public void setOwner(Person owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public int getYears() {
+        return LocalDate.now().minusYears(manufacturingYear).getYear();
+    }
+}

--- a/sample/src/main/java/vehicles/AbstractVehicle.java
+++ b/sample/src/main/java/vehicles/AbstractVehicle.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2016 John Ericksen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package vehicles;
 
 import people.Person;
@@ -5,12 +20,19 @@ import people.Person;
 import java.time.LocalDate;
 
 /**
- * An abstract class for implementing different kinds of {@link Vehicle}.
+ * An abstract class for implementing different kinds of link:Vehicle[].
  *
  * @author http://twitter.com/manoelcampos[Manoel Campos da Silva Filho]
  */
 public class AbstractVehicle implements Vehicle {
+    /**
+     * The year the vehicle was manufactured.
+     */
     private int manufacturingYear;
+
+    /**
+     * The link:Person[] who owns the vehicle.
+     */
     private Person owner;
 
     @Override

--- a/sample/src/main/java/vehicles/Car.java
+++ b/sample/src/main/java/vehicles/Car.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright 2013-2016 John Ericksen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package vehicles;
 
 /**
- * A Car represents a terrestrial {@link Vehicle}
+ * A Car represents a terrestrial link:Vehicle[]
  * with 4 wheels.
  *
  * @author http://twitter.com/manoelcampos[Manoel Campos da Silva Filho]

--- a/sample/src/main/java/vehicles/Car.java
+++ b/sample/src/main/java/vehicles/Car.java
@@ -1,0 +1,32 @@
+package vehicles;
+
+/**
+ * A Car represents a terrestrial {@link Vehicle}
+ * with 4 wheels.
+ *
+ * @author http://twitter.com/manoelcampos[Manoel Campos da Silva Filho]
+ */
+public class Car extends AbstractVehicle {
+    /**
+     * An enumeration to represent left and right sides.
+     */
+    enum Side {LEFT, RIGHT}
+
+    private Side driverSide;
+
+    /**
+     * Gets the side where the driver seats.
+     * @return the driver's seat side
+     */
+    public Side getDriverSide() {
+        return driverSide;
+    }
+
+    /**
+     * Sets the side where the driver seats.
+     * @param driverSide the driver's seat side to set
+     */
+    public void setDriverSide(Side driverSide) {
+        this.driverSide = driverSide;
+    }
+}

--- a/sample/src/main/java/vehicles/Vehicle.java
+++ b/sample/src/main/java/vehicles/Vehicle.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2016 John Ericksen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package vehicles;
 
 import people.Person;
@@ -26,13 +41,13 @@ public interface Vehicle {
     void setManufacturingYear(int year);
 
     /**
-     * Gets the {@link Person} that owns the vehicle.
+     * Gets the link:Person[] that owns the vehicle.
      * @return the vehicle's owner
      */
     Person getOwner();
 
     /**
-     * Sets the {@link Person} that owns the vehicle.
+     * Sets the link:Person[] who owns the vehicle.
      * @param owner the vehicle's owner
      */
     void setOwner(Person owner);

--- a/sample/src/main/java/vehicles/Vehicle.java
+++ b/sample/src/main/java/vehicles/Vehicle.java
@@ -1,0 +1,45 @@
+package vehicles;
+
+import people.Person;
+
+/**
+ * An interface to represent different kinds of Vehicles such as:
+ * - cars
+ * - motorcicles
+ * - airplanes
+ * - boats
+ *
+ * @author http://twitter.com/manoelcampos[Manoel Campos da Silva Filho]
+ * @see https://en.wikipedia.org/wiki/Vehicle[Vehicles at Wikipedia]
+ */
+public interface Vehicle {
+    /**
+     * Gets the year the vehicle was manufactured
+     * @return the manufacturing year
+     */
+    int getManufacturingYear();
+
+    /**
+     * Sets the year the vehicle was manufactured
+     * @param year the year to set
+     */
+    void setManufacturingYear(int year);
+
+    /**
+     * Gets the {@link Person} that owns the vehicle.
+     * @return the vehicle's owner
+     */
+    Person getOwner();
+
+    /**
+     * Sets the {@link Person} that owns the vehicle.
+     * @param owner the vehicle's owner
+     */
+    void setOwner(Person owner);
+
+    /**
+     * Gets the vehicle age in number of years since it was manufactured.
+     * @return the vehicle age in years
+     */
+    int getYears();
+}

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -35,14 +35,17 @@ public class ExportDoclet extends Doclet {
      */
     private final RootDoc rootDoc;
 
+    private final ExportRenderer renderer;
+
     /**
      * Creates a ExportDoclet to export javadoc comments to asciidoc files.
      *
-     * @param rootDoc holds the root of the program structure information.
+     * @param rootDoc the root of the program structure information.
      *                From this root all other program structure information can be extracted.
      */
     public ExportDoclet(RootDoc rootDoc) {
         this.rootDoc = rootDoc;
+        this.renderer = new ExportRenderer();
     }
 
     /**
@@ -89,11 +92,14 @@ public class ExportDoclet extends Doclet {
      */
     @SuppressWarnings("UnusedDeclaration")
     public static boolean start(RootDoc rootDoc) {
-        return new ExportDoclet(rootDoc).start();
+        return new ExportDoclet(rootDoc).render();
     }
 
-    boolean start() {
-        ExportRenderer renderer = new ExportRenderer();
+    /**
+     * Renders the javadoc documentation for all elements inside the {@link #rootDoc} attribute.
+     * @return true if the {@link #rootDoc} was rendered successfully, false otherwise
+     */
+    private boolean render(){
         return renderer.render(rootDoc);
     }
 }

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -30,24 +30,6 @@ import com.sun.javadoc.RootDoc;
 public class ExportDoclet extends Doclet {
 
     /**
-     * Inner class commend
-     */
-    public static class InnerClass {
-
-        /**
-         * Inner class constructor
-         */
-        public InnerClass(){
-
-        }
-
-        /**
-         * Inner class method
-         */
-        public void run(){}
-    }
-
-    /**
      * Holds the root of the program structure information.
      * From this root all other program structure information can be extracted.
      */

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -21,7 +21,7 @@ import com.sun.javadoc.LanguageVersion;
 import com.sun.javadoc.RootDoc;
 
 /**
- * A {@link Doclet} that exports javadoc comments containing asciidoc text to asciidoc files,
+ * A {@link Doclet} that exports javadoc comments containing AsciiDoc text to AsciiDoc files,
  * instead of specific final formats such as HTML.
  *
  * @author John Ericksen
@@ -38,7 +38,7 @@ public class ExportDoclet extends Doclet {
     private final ExportRenderer renderer;
 
     /**
-     * Creates a ExportDoclet to export javadoc comments to asciidoc files.
+     * Creates a ExportDoclet to export javadoc comments to AsciiDoc files.
      *
      * @param rootDoc the root of the program structure information.
      *                From this root all other program structure information can be extracted.

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -36,7 +36,7 @@ public class ExportDoclet extends Doclet {
     private final RootDoc rootDoc;
 
     /**
-     * Creates a ExportDoclet.
+     * Creates a ExportDoclet to export javadoc comments to asciidoc files.
      *
      * @param rootDoc holds the root of the program structure information.
      *                From this root all other program structure information can be extracted.
@@ -46,26 +46,47 @@ public class ExportDoclet extends Doclet {
     }
 
     /**
-     * Method comment
-     * @param options
-     * @param errorReporter
-     * @return
+     * Validates command line options.
+     *
+     * @param options the array of given options
+     * @param errorReporter an object that allows printing error messages for invalid options
+     * @return true if the options are valid, false otherwise
+     * @see Doclet#validOptions(String[][], DocErrorReporter)
      */
     @SuppressWarnings("UnusedDeclaration")
     public static boolean validOptions(String[][] options, DocErrorReporter errorReporter) {
         return new StandardAdapter().validOptions(options, errorReporter);
     }
 
+    /**
+     * Gets the number of arguments that a given command line option must contain.
+     * @param option the command line option
+     * @return the number of arguments required for the given option
+     * @see Doclet#optionLength(String)
+     */
     @SuppressWarnings("UnusedDeclaration")
     public static int optionLength(String option) {
         return new StandardAdapter().optionLength(option);
     }
 
+    /**
+     * Return the version of the Java Programming Language supported
+     * by this doclet.
+     * @return the Java language supported version
+     * @see Doclet#languageVersion()
+     */
     @SuppressWarnings("UnusedDeclaration")
     public static LanguageVersion languageVersion() {
         return LanguageVersion.JAVA_1_5;
     }
 
+    /**
+     * Starts the doclet.
+     * @param rootDoc the root of the program structure information.
+     *                From this root all other program structure information can be extracted.
+     * @return true if the doclet was started successfuly, false otherwise
+     * @see Doclet#start(RootDoc)
+     */
     @SuppressWarnings("UnusedDeclaration")
     public static boolean start(RootDoc rootDoc) {
         return new ExportDoclet(rootDoc).start();

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -20,9 +20,12 @@ import com.sun.javadoc.Doclet;
 import com.sun.javadoc.LanguageVersion;
 import com.sun.javadoc.RootDoc;
 
-
 /**
- * Class level comment
+ * A {@link Doclet} that exports javadoc comments containing asciidoc text to asciidoc files,
+ * instead of specific final formats such as HTML.
+ *
+ * @author John Ericksen
+ * @see ExportRenderer
  */
 public class ExportDoclet extends Doclet {
 
@@ -45,13 +48,16 @@ public class ExportDoclet extends Doclet {
     }
 
     /**
-     * Field comment
+     * Holds the root of the program structure information.
+     * From this root all other program structure information can be extracted.
      */
     private final RootDoc rootDoc;
 
     /**
-     * Constructor comment
-     * @param rootDoc
+     * Creates a ExportDoclet.
+     *
+     * @param rootDoc holds the root of the program structure information.
+     *                From this root all other program structure information can be extracted.
      */
     public ExportDoclet(RootDoc rootDoc) {
         this.rootDoc = rootDoc;

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -29,13 +29,19 @@ import com.sun.javadoc.RootDoc;
  */
 public class ExportDoclet extends Doclet {
 
-    /**
-     * Holds the root of the program structure information.
-     * From this root all other program structure information can be extracted.
-     */
-    private final RootDoc rootDoc;
-
     private final ExportRenderer renderer;
+
+    /**
+     * Starts the doclet.
+     * @param rootDoc the root of the program structure information.
+     *                From this root all other program structure information can be extracted.
+     * @return true if the doclet was started successfuly, false otherwise
+     * @see Doclet#start(RootDoc)
+     */
+    @SuppressWarnings("UnusedDeclaration")
+    public static boolean start(RootDoc rootDoc) {
+        return new ExportDoclet(rootDoc).render();
+    }
 
     /**
      * Creates a ExportDoclet to export javadoc comments to AsciiDoc files.
@@ -44,8 +50,7 @@ public class ExportDoclet extends Doclet {
      *                From this root all other program structure information can be extracted.
      */
     public ExportDoclet(RootDoc rootDoc) {
-        this.rootDoc = rootDoc;
-        this.renderer = new ExportRenderer();
+        this.renderer = new ExportRenderer(rootDoc);
     }
 
     /**
@@ -84,22 +89,11 @@ public class ExportDoclet extends Doclet {
     }
 
     /**
-     * Starts the doclet.
-     * @param rootDoc the root of the program structure information.
-     *                From this root all other program structure information can be extracted.
-     * @return true if the doclet was started successfuly, false otherwise
-     * @see Doclet#start(RootDoc)
-     */
-    @SuppressWarnings("UnusedDeclaration")
-    public static boolean start(RootDoc rootDoc) {
-        return new ExportDoclet(rootDoc).render();
-    }
-
-    /**
-     * Renders the javadoc documentation for all elements inside the {@link #rootDoc} attribute.
-     * @return true if the {@link #rootDoc} was rendered successfully, false otherwise
+     * Renders the javadoc documentation for all elements inside the {@link RootDoc} object
+     * received by this doclet.
+     * @return true if the {@link RootDoc} was rendered successfully, false otherwise
      */
     private boolean render(){
-        return renderer.render(rootDoc);
+        return renderer.render();
     }
 }

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 John Ericksen
+ * Copyright 2013-2016 John Ericksen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.sun.javadoc.LanguageVersion;
 import com.sun.javadoc.RootDoc;
 
 /**
- * A {@link Doclet} that exports javadoc comments containing AsciiDoc text to AsciiDoc files,
+ * A link:Doclet[] that exports javadoc comments containing AsciiDoc text to AsciiDoc files,
  * instead of specific final formats such as HTML.
  *
  * @author John Ericksen
@@ -89,9 +89,9 @@ public class ExportDoclet extends Doclet {
     }
 
     /**
-     * Renders the javadoc documentation for all elements inside the {@link RootDoc} object
+     * Renders the javadoc documentation for all elements inside the link:RootDoc[] object
      * received by this doclet.
-     * @return true if the {@link RootDoc} was rendered successfully, false otherwise
+     * @return true if the link:RootDoc[] was rendered successfully, false otherwise
      */
     private boolean render(){
         return renderer.render();

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -72,14 +72,6 @@ public class ExportDoclet extends Doclet {
     }
 
     boolean start() {
-        return run();
-    }
-
-    /**
-     * Private method comment
-     * @return
-     */
-    private boolean run() {
         ExportRenderer renderer = new ExportRenderer();
         return renderer.render(rootDoc);
     }

--- a/src/main/java/org/asciidoctor/ExportDoclet.java
+++ b/src/main/java/org/asciidoctor/ExportDoclet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013-2015 John Ericksen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/asciidoctor/ExportRenderer.java
+++ b/src/main/java/org/asciidoctor/ExportRenderer.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * A renderer class that actually exports javadoc comments containing asciidoc text to asciidoc files,
+ * A renderer class that actually exports javadoc comments containing AsciiDoc text to AsciiDoc files,
  * instead of specific final formats such as HTML.
  * It is used when the {@link ExportDoclet} is started.
  *
@@ -39,7 +39,7 @@ import java.util.Set;
 public class ExportRenderer {
 
     /**
-     * Renders classes and packages javadocs, inside a {@link RootDoc} object, to asciidoc files.
+     * Renders classes and packages javadocs, inside a {@link RootDoc} object, to AsciiDoc files.
      *
      * @param rootDoc holds the root of the program structure information.
      *                From this root all other program structure information can be extracted.
@@ -61,11 +61,11 @@ public class ExportRenderer {
     }
 
     /**
-     * Renders a class documentation to an asciidoc file.
+     * Renders a class documentation to an AsciiDoc file.
      *
      * @param doc the class documentation object
      */
-    public void renderClass(ClassDoc doc) {
+    private void renderClass(ClassDoc doc) {
         try {
             PrintWriter writer = getWriter(doc.containingPackage(), doc.name());
             if (doc.position() != null) {
@@ -95,11 +95,11 @@ public class ExportRenderer {
     }
 
     /**
-     * Renders a package documentation to an asciidoc file.
+     * Renders a package documentation to an AsciiDoc file.
      *
      * @param doc the package documentation object
      */
-    public void renderPackage(PackageDoc doc){
+    private void renderPackage(PackageDoc doc){
         try {
             PrintWriter writer = getWriter(doc, "package-info");
             writer.println(doc.name());
@@ -119,11 +119,11 @@ public class ExportRenderer {
 
     /**
      * Exports a javadoc comment using a given {@link PrintWriter}, surrounding
-     * it by a asciidoc tag with a specific name.
+     * it by a AsciiDoc tag with a specific name.
      *
-     * @param tag the name of the tag to surround the javadoc comment into the asciidoc file
+     * @param tag the name of the tag to surround the javadoc comment into the AsciiDoc file
      * @param comment the javadoc comment to export
-     * @param writer the {@link PrintWriter} to be used to export the javadoc comment to an asciidoc file
+     * @param writer the {@link PrintWriter} to be used to export the javadoc comment to an AsciiDoc file
      */
     private void outputText(String tag, String comment, PrintWriter writer) {
         writer.println("// tag::" + tag + "[]");
@@ -131,7 +131,7 @@ public class ExportRenderer {
         writer.println("// end::" + tag + "[]");
     }
 
-    protected String cleanJavadocInput(String input) {
+    private String cleanJavadocInput(String input) {
         return input.trim()
                 .replaceAll("\n ", "\n") // Newline space to accommodate javadoc newlines.
                 .replaceAll("(?m)^( *)\\*\\\\/$", "$1*/"); // Multi-line comment end tag is translated into */.
@@ -139,19 +139,20 @@ public class ExportRenderer {
 
     /**
      * Gets a {@link PrintWriter} to export the documentation of a class or package
-     * to an asciidoc file.
+     * to an AsciiDoc file.
      *
      * @param packageDoc the package documentation object that will be the package that the documentation
      *                   is being exported or the package of the class that its documentation
      *                   is being exported
-     * @param name the name of the asciidoc file to export the documentation to
+     * @param name the name of the AsciiDoc file to export the documentation to
      */
     private PrintWriter getWriter(PackageDoc packageDoc, String name) throws FileNotFoundException {
-        File pacakgeDirectory = new File(packageDoc.name().replace('.', File.separatorChar));
-        if(!pacakgeDirectory.exists()){
-            pacakgeDirectory.mkdirs();
+        File packageDirectory = new File(packageDoc.name().replace('.', File.separatorChar));
+        if(!packageDirectory.exists() && !packageDirectory.mkdirs()){
+            throw new RuntimeException("The directory was not created due to unknown reason.");
         }
-        File file = new File(pacakgeDirectory, name + ".adoc");
+
+        File file = new File(packageDirectory, name + ".adoc");
         return new PrintWriter(new OutputStreamWriter(new FileOutputStream(file)));
     }
 }

--- a/src/main/java/org/asciidoctor/ExportRenderer.java
+++ b/src/main/java/org/asciidoctor/ExportRenderer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2015 John Ericksen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.asciidoctor;
 
 import com.sun.javadoc.AnnotationTypeDoc;

--- a/src/main/java/org/asciidoctor/ExportRenderer.java
+++ b/src/main/java/org/asciidoctor/ExportRenderer.java
@@ -30,23 +30,41 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
+ * A renderer class that actually exports javadoc comments containing asciidoc text to asciidoc files,
+ * instead of specific final formats such as HTML.
+ * It is used when the {@link ExportDoclet} is started.
+ *
  * @author John Ericksen
  */
 public class ExportRenderer {
 
+    /**
+     * Renders classes and packages javadocs, inside a {@link RootDoc} object, to asciidoc files.
+     *
+     * @param rootDoc holds the root of the program structure information.
+     *                From this root all other program structure information can be extracted.
+     * @return true if successful, false otherwise
+     */
     public boolean render(RootDoc rootDoc) {
         Set<PackageDoc> packages = new HashSet<PackageDoc>();
         for (ClassDoc doc : rootDoc.classes()) {
             packages.add(doc.containingPackage());
             renderClass(doc);
         }
+
         for (PackageDoc doc : packages) {
             renderPackage(doc);
             //renderer.renderDoc(doc);
         }
+
         return true;
     }
 
+    /**
+     * Renders a class documentation to an asciidoc file.
+     *
+     * @param doc the class documentation object
+     */
     public void renderClass(ClassDoc doc) {
         try {
             PrintWriter writer = getWriter(doc.containingPackage(), doc.name());
@@ -76,6 +94,11 @@ public class ExportRenderer {
         }
     }
 
+    /**
+     * Renders a package documentation to an asciidoc file.
+     *
+     * @param doc the package documentation object
+     */
     public void renderPackage(PackageDoc doc){
         try {
             PrintWriter writer = getWriter(doc, "package-info");
@@ -94,6 +117,14 @@ public class ExportRenderer {
         }
     }
 
+    /**
+     * Exports a javadoc comment using a given {@link PrintWriter}, surrounding
+     * it by a asciidoc tag with a specific name.
+     *
+     * @param tag the name of the tag to surround the javadoc comment into the asciidoc file
+     * @param comment the javadoc comment to export
+     * @param writer the {@link PrintWriter} to be used to export the javadoc comment to an asciidoc file
+     */
     private void outputText(String tag, String comment, PrintWriter writer) {
         writer.println("// tag::" + tag + "[]");
         writer.println(cleanJavadocInput(comment));
@@ -106,6 +137,15 @@ public class ExportRenderer {
                 .replaceAll("(?m)^( *)\\*\\\\/$", "$1*/"); // Multi-line comment end tag is translated into */.
     }
 
+    /**
+     * Gets a {@link PrintWriter} to export the documentation of a class or package
+     * to an asciidoc file.
+     *
+     * @param packageDoc the package documentation object that will be the package that the documentation
+     *                   is being exported or the package of the class that its documentation
+     *                   is being exported
+     * @param name the name of the asciidoc file to export the documentation to
+     */
     private PrintWriter getWriter(PackageDoc packageDoc, String name) throws FileNotFoundException {
         File pacakgeDirectory = new File(packageDoc.name().replace('.', File.separatorChar));
         if(!pacakgeDirectory.exists()){

--- a/src/main/java/org/asciidoctor/ExportRenderer.java
+++ b/src/main/java/org/asciidoctor/ExportRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 John Ericksen
+ * Copyright 2013-2016 John Ericksen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * A renderer class that actually exports javadoc comments containing AsciiDoc text to AsciiDoc files,
  * instead of specific final formats such as HTML.
- * It is used when the {@link ExportDoclet} is started.
+ * It is used when the link:ExportDoclet[] is started.
  *
  * @author John Ericksen
  */
@@ -49,7 +49,7 @@ public class ExportRenderer {
     }
 
     /**
-     * Renders classes and packages javadocs, inside a {@link RootDoc} object, to AsciiDoc files.
+     * Renders classes and packages javadocs, inside a link:RootDoc[] object, to AsciiDoc files.
      *
      * @return true if successful, false otherwise
      */
@@ -126,12 +126,12 @@ public class ExportRenderer {
     }
 
     /**
-     * Exports a javadoc comment using a given {@link PrintWriter}, surrounding
+     * Exports a javadoc comment using a given link:PrintWriter[], surrounding
      * it by a AsciiDoc tag with a specific name.
      *
      * @param tag the name of the tag to surround the javadoc comment into the AsciiDoc file
      * @param comment the javadoc comment to export
-     * @param writer the {@link PrintWriter} to be used to export the javadoc comment to an AsciiDoc file
+     * @param writer the link:PrintWriter[] to be used to export the javadoc comment to an AsciiDoc file
      */
     private void outputText(String tag, String comment, PrintWriter writer) {
         writer.println("// tag::" + tag + "[]");
@@ -146,7 +146,7 @@ public class ExportRenderer {
     }
 
     /**
-     * Gets a {@link PrintWriter} to export the documentation of a class or package
+     * Gets a link:PrintWriter[] to export the documentation of a class or package
      * to an AsciiDoc file.
      *
      * @param packageDoc the package documentation object that will be the package that the documentation

--- a/src/main/java/org/asciidoctor/StandardAdapter.java
+++ b/src/main/java/org/asciidoctor/StandardAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 John Ericksen
+ * Copyright 2013-2016 John Ericksen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.sun.javadoc.RootDoc;
 import com.sun.tools.doclets.standard.Standard;
 
 /**
- * Adapter class to use the Standard Javadoc {@link Doclet} in a non-static context.
+ * Adapter class to use the link:Standard[] Javadoc link:Doclet[] in a non-static context.
  *
  * @author John Ericksen
  */

--- a/src/main/java/org/asciidoctor/StandardAdapter.java
+++ b/src/main/java/org/asciidoctor/StandardAdapter.java
@@ -16,11 +16,12 @@
 package org.asciidoctor;
 
 import com.sun.javadoc.DocErrorReporter;
+import com.sun.javadoc.Doclet;
 import com.sun.javadoc.RootDoc;
 import com.sun.tools.doclets.standard.Standard;
 
 /**
- * Adapter class to use the Standard Javadoc Doclet in a non-static context.
+ * Adapter class to use the Standard Javadoc {@link Doclet} in a non-static context.
  *
  * @author John Ericksen
  */

--- a/src/main/java/org/asciidoctor/StandardAdapter.java
+++ b/src/main/java/org/asciidoctor/StandardAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013-2015 John Ericksen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/asciidoctor/package-info.java
+++ b/src/main/java/org/asciidoctor/package-info.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2013-2016 John Ericksen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
- * Package level comments
+ * Provides the classes that implement the link:ExportDoclet[] to extract javadoc comments,
+ * written in AsciiDoc, from java source files and export then to AsciiDoc files.
  * @author John Ericksen
  */
 package org.asciidoctor;


### PR DESCRIPTION
- Performed some refactoring to better organize the code.
- Updated and included missing javadocs.
- Enabled the doclet to accept default command line arguments given to the javadoc tool (initially only the -d, that defines the output directory)
- Provided a complete README that describes the doclet, its goal and how to use it by directly calling the javadoc tool or through maven.
- Included a pre-configured sample maven project.